### PR TITLE
Fix package names in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 tifffile
 numpy
 matplotlib
-PyTorch
+torch
 opencv-python
 albumentations
-sklearn
+scikit-learn


### PR DESCRIPTION
## Summary
- install the correct libraries: switch `PyTorch` to `torch` and `sklearn` to `scikit-learn`

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684ea26ca6d083239199f8d5b7f95cce